### PR TITLE
🐛 Ensuring that schema isn't modified for lazy validator compilation.

### DIFF
--- a/src/decorators/body.ts
+++ b/src/decorators/body.ts
@@ -1,13 +1,14 @@
 import { isJSONSchemaLike, TJSONSchema } from '@bluejay/schema';
 import { ValidateFunction } from 'ajv';
 import { NextFunction, Request, Response } from 'express';
+import * as Lodash from 'lodash';
 import { Config } from '../config';
 import { MetadataKey } from '../constants/metadata-key';
 import { TJSONBodyOptions } from '../types/json-body-options';
 import { before } from './before';
 
 export function body(options: TJSONBodyOptions | TJSONSchema) {
-  const jsonSchema = isJSONSchemaLike(options) ? options : (<TJSONBodyOptions>options).jsonSchema;
+  const jsonSchema = Lodash.cloneDeep(isJSONSchemaLike(options) ? options : (<TJSONBodyOptions>options).jsonSchema);
 
   let validator: ValidateFunction;
   const getValidator = () => {

--- a/src/decorators/json-response.ts
+++ b/src/decorators/json-response.ts
@@ -1,12 +1,14 @@
 import { is2xx, StatusCode } from '@bluejay/status-code';
 import { ValidateFunction } from 'ajv';
 import { NextFunction, Request, Response } from 'express';
+import * as Lodash from 'lodash';
 import { Config } from '../config';
 import { MetadataKey } from '../constants/metadata-key';
 import { TJSONResponseOptions } from '../types/json-response-options';
 import { before } from './before';
 
 export function jsonResponse(options: TJSONResponseOptions) {
+  const jsonSchema = Lodash.cloneDeep(options.jsonSchema);
   const isStatusCodesArray = Array.isArray(options.statusCode);
 
   let validator: ValidateFunction;
@@ -15,7 +17,7 @@ export function jsonResponse(options: TJSONResponseOptions) {
       return validator;
     }
     const ajvInstance = Config.get('jsonResponseAJVFactory', options.ajvFactory)();
-    validator = ajvInstance.compile(options.jsonSchema);
+    validator = ajvInstance.compile(jsonSchema);
     return validator;
   };
 

--- a/src/decorators/params.ts
+++ b/src/decorators/params.ts
@@ -1,13 +1,14 @@
 import { isJSONSchemaLike, TJSONSchema } from '@bluejay/schema';
 import { ValidateFunction } from 'ajv';
 import { NextFunction, Request, Response } from 'express';
+import * as Lodash from 'lodash';
 import { Config } from '../config';
 import { MetadataKey } from '../constants/metadata-key';
 import { TParamsOptions } from '../types/params-options';
 import { before } from './before';
 
 export function params(options: TParamsOptions | TJSONSchema) {
-  const jsonSchema = isJSONSchemaLike(options) ? options : (<TParamsOptions>options).jsonSchema;
+  const jsonSchema = Lodash.cloneDeep(isJSONSchemaLike(options) ? options : (<TParamsOptions>options).jsonSchema);
 
   let validator: ValidateFunction;
   const getValidator = () => {

--- a/src/decorators/query.ts
+++ b/src/decorators/query.ts
@@ -1,13 +1,14 @@
 import { isJSONSchemaLike, TJSONSchema } from '@bluejay/schema';
 import { ValidateFunction } from 'ajv';
 import { NextFunction, Request, Response } from 'express';
+import * as Lodash from 'lodash';
 import { Config } from '../config';
 import { MetadataKey } from '../constants/metadata-key';
 import { TQueryOptions } from '../types/query-options';
 import { before } from './before';
 
 export function query(options: TQueryOptions | TJSONSchema) {
-  const jsonSchema = isJSONSchemaLike(options) ? options : (<TQueryOptions>options).jsonSchema;
+  const jsonSchema = Lodash.cloneDeep(isJSONSchemaLike(options) ? options : (<TQueryOptions>options).jsonSchema);
   const groups = (<TQueryOptions>options).groups;
   const transform = (<TQueryOptions>options).transform;
 


### PR DESCRIPTION
Idea is to copy the important jsonSchema param because it's used in the lazy evaluation. We could also just copy the entire options param, but this seems to be a bit slimmer.